### PR TITLE
Don't highlight trailing spaces within the current line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**0.0.5**  
+Don't highlight trailing spaces within the current line  
+
 **0.0.4**  
 Add config option to start highlighting automatically  
 

--- a/config.json
+++ b/config.json
@@ -54,7 +54,7 @@
         }
     },{
         "name": "trailing",
-        "enabled": "inactiveLines",
+        "enabled": "unlessCursorAtEndOfPattern",
         "pattern": "[^\\S\\r\\n]+$",
         "style": {
             "borderWidth": "1px",

--- a/config.json
+++ b/config.json
@@ -54,7 +54,7 @@
         }
     },{
         "name": "trailing",
-        "enabled": false,
+        "enabled": "inactiveLines",
         "pattern": "[^\\S\\r\\n]+$",
         "style": {
             "borderWidth": "1px",

--- a/extension.js
+++ b/extension.js
@@ -127,7 +127,7 @@ function activate(context) {
                 var range = {range: new vscode.Range(startPos, endPos)};
                 if (cur.enabled === 'inactiveLines' && startPos.line === activeEditor.selection.active.line) {
                     continue;
-            }
+                }
                 decChars[idx].chars.push(range);
             }
         });

--- a/extension.js
+++ b/extension.js
@@ -84,6 +84,13 @@ function activate(context) {
             }
         }, null, context.subscriptions);
         
+        // And when changing the selection or moving the cursor
+        vscode.window.onDidChangeTextEditorSelection(event => {
+            if (activeEditor && event.textEditor === activeEditor) {
+                triggerUpdate();
+            }
+        }, null, context.subscriptions);
+        
         // Set timeout for updating decorations
         var timeout = null;
         function triggerUpdate() {
@@ -118,6 +125,9 @@ function activate(context) {
                 var startPos = activeEditor.document.positionAt(match.index);
                 var endPos = activeEditor.document.positionAt(match.index + match[0].length);
                 var range = {range: new vscode.Range(startPos, endPos)};
+                if (cur.enabled === 'inactiveLines' && startPos.line === activeEditor.selection.active.line) {
+                    continue;
+            }
                 decChars[idx].chars.push(range);
             }
         });

--- a/extension.js
+++ b/extension.js
@@ -125,7 +125,15 @@ function activate(context) {
                 var startPos = activeEditor.document.positionAt(match.index);
                 var endPos = activeEditor.document.positionAt(match.index + match[0].length);
                 var range = {range: new vscode.Range(startPos, endPos)};
-                if (cur.enabled === 'inactiveLines' && startPos.line === activeEditor.selection.active.line) {
+                if (activeEditor.selection.active.isEqual(endPos)
+                    && cur.enabled == 'unlessCursorAtEndOfPattern') {
+                    continue;
+                } else if (activeEditor.selection.active.isAfterOrEqual(startPos)
+                    && activeEditor.selection.active.isBeforeOrEqual(endPos)
+                    && cur.enabled == 'unlessCursorWithinPattern') {
+                    continue;
+                } else if (startPos.line == activeEditor.selection.active.line
+                    && cur.enabled == 'unlessCursorOnSameLine') {
                     continue;
                 }
                 decChars[idx].chars.push(range);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "whitespace-plus",
     "displayName": "Whitespace+",
     "description": "Clearly mark whitespace characters (including trailing) and custom patterns.",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "publisher": "davidhouchin",
     "readme": "README.md",
     "icon": "icon.png",


### PR DESCRIPTION
This is a small enhancement to allow patterns to be enabled only for inactive lines since some people find highlighting trailing whitespace in the current line to be too distracting.